### PR TITLE
Removed references to 'Ruff' and updated to use 'Black'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ This will allow you to make changes to the package and have them reflected in yo
 1. Install the Python extension for VSCode.
 2. Install the Python Debugger Extension for VSCode.
 3. Install Pylance for VSCode.
-4. Install Ruff for VSCode.
+4. Install Black Formatter Extension from Microsoft for VSCode.
+    - Once downloaded, open the setting ctrl+shift+p and then search Open User Settings (JSON)
+    - Add the following to the JSON file.
+    ```
+      "[python]": {
+    "editor.formatOnType": true,
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+    },
+    ```
 5. Set your Python interpreter to the virtual environment you created.
 6. To run notebooks inside of VSCode you can install the Jupyter extension. (Optional)
 
@@ -42,7 +51,6 @@ The .vscode/settings.json file allows you to execute scripts directly inside of 
 ## Best Practices
 - Create a new branch for each feature or bug fix.
 - Use absolute imports when importing from the `ai_server` package.
-- Turn Ruff extension on and fix warnings before making a pull request.
 - Run unit tests before making a pull request. (See TESTING.md for instructions)
 - Update requirements-dev.txt, pyproject.toml, and setup.py if you add new dependencies.
 


### PR DESCRIPTION
Removed any references to Ruff formatter in the readme.md file and replaced all cases with the 'Black Formatter' from Microsoft. This would be for the VSCode set up section.


- [x ]  Removed References to Ruff
- [x ] Replaced with Black and added instructions for formatter set up