### PR TITLE
updating sdk tests to pull enging_ids from os vars

### DIFF
--- a/python/ai-server/src/ai_server/tests/.env.example
+++ b/python/ai-server/src/ai_server/tests/.env.example
@@ -1,4 +1,23 @@
+# Local Creds - SWAP THESE WITH YOUR OWN VALUES - make sure to wrap values around ' '
 SECRET_KEY=your_secret_key
 ACCESS_KEY=your_access_key
+LOCAL_ENDPOINT=your_local_endpoint
+LOCAL_LLM_CHAT_ENGINE_ID=your_local_llm_chat_engine_id
+LOCAL_LLM_EMBEDDING_ENGINE_ID=your_llm_embedding_engine_id
+LOCAL_VECTOR_ENGINE_ID=your_local_vector_engine_id
+LOCAL_DATABASE_ENGINE_ID=your_local_database_engine_id
+LOCAL_STORAGE_ENGINE_ID=your_local_storage_engine_id
+
+# Dev Creds - SWAP THESE WITH YOUR OWN VALUES - make sure to wrap values around ' '
 DEV_SECRET_KEY=your_dev_secret_key
 DEV_ACCESS_KEY=your_dev_access_key
+DEV_ENDPOINT=your_dev_endpoint
+DEV_LLM_CHAT_ENGINE_ID=you_dev_llm_chat_engine_id
+DEV_LLM_EMBEDDING_ENGINE_ID=your_dev_llm_embedding_engine_id
+DEV_VECTOR_ENGINE_ID=your_dev_vector_engine_id
+DEV_STORAGE_ENGINE_ID=your_dev_storage_enging_id
+
+# SWAP THIS VALUE TO CHANGE BETWEEN LOCAL AND DEV CREDENTIALS
+# 'dev_creds' if testing DEV
+# 'local_creds' if testing Local
+ACTIVE_CREDS=test_local_or_dev_creds

--- a/python/ai-server/src/ai_server/tests/.env.example
+++ b/python/ai-server/src/ai_server/tests/.env.example
@@ -1,6 +1,6 @@
 # Local Creds - SWAP THESE WITH YOUR OWN VALUES - make sure to wrap values around ' '
-SECRET_KEY=your_secret_key
-ACCESS_KEY=your_access_key
+LOCAL_SECRET_KEY=your_local_secret_key
+LOCAL_ACCESS_KEY=your_local_access_key
 LOCAL_ENDPOINT=your_local_endpoint
 LOCAL_LLM_CHAT_ENGINE_ID=your_local_llm_chat_engine_id
 LOCAL_LLM_EMBEDDING_ENGINE_ID=your_llm_embedding_engine_id

--- a/python/ai-server/src/ai_server/tests/variables.py
+++ b/python/ai-server/src/ai_server/tests/variables.py
@@ -8,16 +8,16 @@ if load_dotenv():
 else:
     print(f"Failed to load environment variables")
 
-# SWAP THESE WITH YOUR OWN VALUES IF TESTING LOCALLY
+# Insert these in .env file
 local_creds = {
-    'SECRET_KEY': os.getenv('SECRET_KEY'),
-    'ACCESS_KEY': os.getenv('ACCESS_KEY'),
+    'SECRET_KEY': os.getenv('LOCAL_SECRET_KEY'),
+    'ACCESS_KEY': os.getenv('LOCAL_ACCESS_KEY'),
     'ENDPOINT': os.getenv('LOCAL_ENDPOINT'),
     'LLM_CHAT_ENGINE_ID': os.getenv('LOCAL_LLM_CHAT_ENGINE_ID'),
-    'LLM_EMBEDDING_ENGINE_ID': os.getenv('LOCAL_LLM_EMBEDDING_ENGINE_ID'), # this is chat gpt 4o that was given access to me from ryan
-    'VECTOR_ENGINE_ID': os.getenv('LOCAL_VECTOR_ENGINE_ID'), # I dont have access to this one either, now i do i think
-    'DATABASE_ENGINE_ID': os.getenv('LOCAL_DATABASE_ENGINE_ID'), #I added this one
-    'STORAGE_ENGINE_ID': os.getenv('LOCAL_STORAGE_ENGINE_ID'), #ryan said to make this non
+    'LLM_EMBEDDING_ENGINE_ID': os.getenv('LOCAL_LLM_EMBEDDING_ENGINE_ID'), 
+    'VECTOR_ENGINE_ID': os.getenv('LOCAL_VECTOR_ENGINE_ID'),
+    'DATABASE_ENGINE_ID': os.getenv('LOCAL_DATABASE_ENGINE_ID'),
+    'STORAGE_ENGINE_ID': os.getenv('LOCAL_STORAGE_ENGINE_ID'),
 }
 
 # Don't change these values unless there are problems ie. permissions, etc.
@@ -27,7 +27,7 @@ dev_creds = {
     'ENDPOINT': os.getenv('DEV_ENDPOINT'),
     'LLM_CHAT_ENGINE_ID': os.getenv('DEV_LLM_CHAT_ENGINE_ID'),
     'LLM_EMBEDDING_ENGINE_ID': os.getenv('DEV_LLM_EMBEDDING_ENGINE_ID'),
-    'VECTOR_ENGINE_ID': os.getenv('DEV_VECTOR_ENGINE_ID'), #now I have access, this is different than the one i started with
+    'VECTOR_ENGINE_ID': os.getenv('DEV_VECTOR_ENGINE_ID'),
     'DATABASE_ENGINE_ID': os.getenv('DEV_DATABASE_ENGINE_ID'),
     'STORAGE_ENGINE_ID': os.getenv('DEV_STORAGE_ENGINE_ID'),
 }

--- a/python/ai-server/src/ai_server/tests/variables.py
+++ b/python/ai-server/src/ai_server/tests/variables.py
@@ -10,29 +10,36 @@ else:
 
 # SWAP THESE WITH YOUR OWN VALUES IF TESTING LOCALLY
 local_creds = {
-    'SECRET_KEY': os.getenv('LOCAL_SECRET_KEY'),
-    'ACCESS_KEY': os.getenv('LOCAL_ACCESS_KEY'),
-    'ENDPOINT': "http://localhost:9090/Monolith_Dev/api",
-    'LLM_CHAT_ENGINE_ID': '4801422a-5c62-421e-a00c-05c6a9e15de8',
-    'LLM_EMBEDDING_ENGINE_ID': '',
-    'VECTOR_ENGINE_ID': 'dae9096d-1891-4077-b8bc-63ecdce08e14',
-    'DATABASE_ENGINE_ID': '515721c0-340f-42fa-b3ff-138882b8b75b'
+    'SECRET_KEY': os.getenv('SECRET_KEY'),
+    'ACCESS_KEY': os.getenv('ACCESS_KEY'),
+    'ENDPOINT': os.getenv('LOCAL_ENDPOINT'),
+    'LLM_CHAT_ENGINE_ID': os.getenv('LOCAL_LLM_CHAT_ENGINE_ID'),
+    'LLM_EMBEDDING_ENGINE_ID': os.getenv('LOCAL_LLM_EMBEDDING_ENGINE_ID'), # this is chat gpt 4o that was given access to me from ryan
+    'VECTOR_ENGINE_ID': os.getenv('LOCAL_VECTOR_ENGINE_ID'), # I dont have access to this one either, now i do i think
+    'DATABASE_ENGINE_ID': os.getenv('LOCAL_DATABASE_ENGINE_ID'), #I added this one
+    'STORAGE_ENGINE_ID': os.getenv('LOCAL_STORAGE_ENGINE_ID'), #ryan said to make this non
 }
 
 # Don't change these values unless there are problems ie. permissions, etc.
 dev_creds = {
     'SECRET_KEY': os.getenv('DEV_SECRET_KEY'),
     'ACCESS_KEY': os.getenv('DEV_ACCESS_KEY'),
-    'ENDPOINT': "https://workshop.cfg.deloitte.com/cfg-ai-dev/Monolith/api",
-    'LLM_CHAT_ENGINE_ID': '4801422a-5c62-421e-a00c-05c6a9e15de8',
-    'LLM_EMBEDDING_ENGINE_ID': 'e4449559-bcff-4941-ae72-0e3f18e06660',
-    'VECTOR_ENGINE_ID': '1222b449-1bc6-4358-9398-1ed828e4f26a',
-    'DATABASE_ENGINE_ID': '950eb187-e352-444d-ad6a-6476ed9390af',
-    'STORAGE_ENGINE_ID': '2d905aa3-b703-4c98-8133-5bcaefddac1e',
+    'ENDPOINT': os.getenv('DEV_ENDPOINT'),
+    'LLM_CHAT_ENGINE_ID': os.getenv('DEV_LLM_CHAT_ENGINE_ID'),
+    'LLM_EMBEDDING_ENGINE_ID': os.getenv('DEV_LLM_EMBEDDING_ENGINE_ID'),
+    'VECTOR_ENGINE_ID': os.getenv('DEV_VECTOR_ENGINE_ID'), #now I have access, this is different than the one i started with
+    'DATABASE_ENGINE_ID': os.getenv('DEV_DATABASE_ENGINE_ID'),
+    'STORAGE_ENGINE_ID': os.getenv('DEV_STORAGE_ENGINE_ID'),
 }
 
-# SWAP THIS VALUE TO CHANGE BETWEEN LOCAL AND DEV CREDENTIALS
-active_creds = dev_creds
+# Dynamically select the credentials dictionary
+active_creds = os.getenv('ACTIVE_CREDS')
+if active_creds == 'local_creds':
+    active_creds = local_creds
+elif os.getenv('ACTIVE_CREDS') == 'dev_creds':
+    active_creds = dev_creds
+else:
+    raise ValueError(f"Invalid value for ACTIVE_CREDS: {active_creds}")
 
 # These are the variables that will be used in the tests
 SECRET_KEY = active_creds['SECRET_KEY']


### PR DESCRIPTION
## Description
Updated the variables.py file to pull the engine ID's and active creds used in testing from an env file.
https://github.com/SEMOSS/python-sdk/issues/5
python-sdk issue #5 

## Changes Made
changed the .env.example file and the variables.py file so that now the only file being changed in tests folder will be in the created .env file for testing. Variables pulls all variables from the .env file and users will no longer be needed to alter the variables.py file.

## How to Test
1. Follow the steps in the testing document within the tests folder and follow instructions to test unittest python scripts
2. Expected to read all engine_ids and active creds from OS.getenv() call.

## Notes
users will be able to go create a .env file from the .env.example file to fill in their engine_ids to be able to run Unittests