### PR TITLE
Ability to pass use_history param in model calls(SDK)

### DIFF
--- a/python/ai-server/src/ai_server/py_client/gaas/model.py
+++ b/python/ai-server/src/ai_server/py_client/gaas/model.py
@@ -18,7 +18,7 @@ class ModelEngine(ServerProxy):
         self,
         question: str,
         context: Optional[str] = None,
-        use_history: Optional[bool] = True,
+        use_history: Optional[bool] = True,  # To control the history
         insight_id: Optional[str] = None,
         param_dict: Optional[Dict] = None,
     ) -> List[Dict]:
@@ -73,7 +73,7 @@ class ModelEngine(ServerProxy):
         self,
         question: str,
         context: Optional[str] = None,
-        use_history: Optional[bool] = True,
+        use_history: Optional[bool] = True,  # To control the history
         insight_id: Optional[str] = None,
         param_dict: Optional[Dict] = None,
     ) -> Generator:

--- a/python/ai-server/src/ai_server/py_client/gaas/model.py
+++ b/python/ai-server/src/ai_server/py_client/gaas/model.py
@@ -18,6 +18,7 @@ class ModelEngine(ServerProxy):
         self,
         question: str,
         context: Optional[str] = None,
+        use_history: Optional[bool] = True,
         insight_id: Optional[str] = None,
         param_dict: Optional[Dict] = None,
     ) -> List[Dict]:
@@ -55,7 +56,9 @@ class ModelEngine(ServerProxy):
             else ""
         )
 
-        pixel = f'LLM(engine="{self.engine_id}", command="<encode>{question}</encode>"{optionalContext}{optionalParamDict});'
+        use_history_param = str(use_history).lower()
+
+        pixel = f'LLM(engine="{self.engine_id}", command="<encode>{question}</encode>", useHistory={use_history_param}{optionalContext}{optionalParamDict});'
 
         output_payload_message = self.server.run_pixel(
             payload=pixel, insight_id=insight_id, full_response=True
@@ -70,6 +73,7 @@ class ModelEngine(ServerProxy):
         self,
         question: str,
         context: Optional[str] = None,
+        use_history: Optional[bool] = True,
         insight_id: Optional[str] = None,
         param_dict: Optional[Dict] = None,
     ) -> Generator:
@@ -107,7 +111,9 @@ class ModelEngine(ServerProxy):
             else ""
         )
 
-        pixel = f'LLM(engine="{self.engine_id}", command="<encode>{question}</encode>"{optionalContext}{optionalParamDict});'
+        use_history_param = str(use_history).lower()
+
+        pixel = f'LLM(engine="{self.engine_id}", command="<encode>{question}</encode>", useHistory={use_history_param}{optionalContext}{optionalParamDict});'
 
         for message in self.server.get_partial_responses(
             self.server.run_pixel_separate_thread(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Add the ability to call `use_history` to model calls (SDK)
- Update the `ask()` and `stream_ask()` methods in the `ModelEngine` class.

## Changes Made
<!-- List the key changes made in this PR -->
Added the `use_history` as optional parameter for the` ask() & stream_ask()` methods in the `ModelEngine` class of `model.py`

## How to Test
<!-- Explain how reviewers can test your changes -->
```
from ai_server.py_client.gaas.model import ModelEngine
model = ModelEngine(engine_id = "4acbe913-df40-4ac0-b28a-daa5ad91b172")

question = 'My name is Pasu. What should I call you?'
model.ask(question = question, param_dict={"temperature": .1})
# RESPONSE: "Hello Pasu! You can call me Assistant. How can I assist you today?"

question = 'What did I say my name was? This is a test to see if I am passing history.'
model.ask(question = question, param_dict={"temperature": .1})
# RESPONSE: "You mentioned that your name is Pasu. How can I assist you further?"

question = 'What did I say my name was? This is a test to see if I am passing history.'
model.ask(question = question, use_history = False, param_dict={"temperature": .1})
# RESPONSE "I'm sorry, but I can't recall your name as I don't have the capability to remember past interactions or access any personal data. How can I assist you today?"

question = 'What did I say my name was? This is a test to see if I am passing history...'
model.ask(question = question, param_dict={"temperature": .1})
# RESPONSE
```

`LLM("4acbe913-df40-4ac0-b28a-daa5ad91b172", "What is the capital of Connecticut?", useHistory=False)`

## Notes
<!-- Any further notes regarding changes -->