### PR TITLE
fix: moving from run_pixel_separate_thread to run_pixel_async to get proper partials based on unique job ids for the thread

### DIFF
--- a/python/ai-server/pyproject.toml
+++ b/python/ai-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ai-server-sdk"
-version = "0.0.24"
+version = "0.0.25"
 description = "Utility package to connect to AI Server instances."
 readme = "README.md"
 license = "MIT"

--- a/python/ai-server/src/ai_server/__init__.py
+++ b/python/ai-server/src/ai_server/__init__.py
@@ -8,7 +8,7 @@ try:
     __version__ = metadata.version(__package__)
 except metadata.PackageNotFoundError:
     # Case where package metadata is not available.
-    __version__ = "0.0.24"
+    __version__ = "0.0.25"
 del metadata  # optional, avoids polluting the results of dir(__package__)
 
 

--- a/python/ai-server/src/ai_server/py_client/gaas/model.py
+++ b/python/ai-server/src/ai_server/py_client/gaas/model.py
@@ -116,9 +116,7 @@ class ModelEngine(ServerProxy):
         pixel = f'LLM(engine="{self.engine_id}", command="<encode>{question}</encode>", useHistory={use_history_param}{optionalContext}{optionalParamDict});'
 
         for message in self.server.get_partial_responses(
-            self.server.run_pixel_separate_thread(
-                payload=pixel, insight_id=insight_id, full_response=True
-            )
+            self.server.run_pixel_async(payload=pixel, insight_id=insight_id)
         ):
             if message and message.strip():
                 yield message


### PR DESCRIPTION
Example usage:

```py
import threading
import ai_server
from ai_server import ServerClient, ModelEngine

# Step 1: Authenticate
server_connection = ai_server.ServerClient(
    access_key="<your access id>",
    secret_key="<your secret id>",
    base="http://localhost:8080/Monolith/api", # update your base
)

# Step 2: Thread function
def ask_in_thread(thread_id, question):
    model = ModelEngine(
        engine_id="4801422a-5c62-421e-a00c-05c6a9e15de8", # update your engine id
        insight_id=server_connection.cur_insight,
    )
    print(f"\n[Thread {thread_id}] Asking: {question}")
    response = ""
    for chunk in model.stream_ask(question=question):
        print(f"[Thread {thread_id}] {chunk.strip()}", flush=True)
        response += chunk
    print(f"\n[Thread {thread_id}] Final Response: {response}\n")


# Step 3: Questions
q1 = "What is the capital of France?"
q2 = "What is the square root of 144?"

# Step 4: Create and run threads
thread1 = threading.Thread(target=ask_in_thread, args=(1, q1))
thread2 = threading.Thread(target=ask_in_thread, args=(2, q2))

thread1.start()
thread2.start()

thread1.join()
thread2.join()
```