### PR TITLE
fix: need to init required_headers before login calls

### DIFF
--- a/python/ai-server/src/ai_server/server_resources/server_client.py
+++ b/python/ai-server/src/ai_server/server_resources/server_client.py
@@ -83,6 +83,10 @@ class ServerClient:
                 "Must provide either access_key and secret_key for user access login or provide bearer_token and bearer_token_provider for login using your IdP access key"
             )
 
+
+        # This will hold CSRF and any other required headers (merge into all calls)
+        self.required_headers = {}
+
         # TODO provide definitons for all of these attributes
         # used to keep track of the authorization header after the user has authenticated
         self.auth_headers: Dict = {}
@@ -90,9 +94,6 @@ class ServerClient:
             self.loginUserAccessKey()
         else:
             self.loginBearerToken()
-
-        # This will hold CSRF and any other required headers (merge into all calls)
-        self.required_headers = {}
 
         # Perform CSRF/config logic (but don't crash if config fails)
         self.set_csrf_if_enabled()


### PR DESCRIPTION
## Description
Client initialization was failing when login calls tried to update a missing variable `required_headers`

## Changes Made
Move the initialization of the `required_headers` variable in the `server_client` to before the login calls 

## How to Test
Following the usage instructions initialize a client

```
from ai_server import ServerClient
loginKeys = {"accessKey":"...", "secretKey":"..."}
server_connection = ServerClient(base='.../Monolith/api', access_key=loginKeys['accessKey'], secret_key=loginKeys['secretKey'])
print(server_connection.run_pixel('1+1'))
```

## Notes
